### PR TITLE
add necessary ignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+autom4te.cache/
+
+configure
+config.log
+config.status
+
+Makefile
+contrib/Makefile
+doc/Makefile
+m4/Makefile
+src/Makefile
+
+src/.deps/
+src/cdargs.o
+src/cdargs


### PR DESCRIPTION
ATT.
When we use autotools build frame, a good ignore file is necessary.