### PR TITLE
Fix build for musl

### DIFF
--- a/src/cdargs.cc
+++ b/src/cdargs.cc
@@ -56,6 +56,7 @@ using namespace std;
 # include <unistd.h>
 # include <signal.h>
 # include <string.h>
+# include <limits.h>
 
 //# if defined(USE_NCURSES) && !defined(RENAMED_NCURSES)
 # if defined(HAVE_NCURSES_H)


### PR DESCRIPTION
build failed due to PATH_MAX missing on musl libc

In musl PATH_MAX is declared in limits.h and not automatically pulled in. 

See also: https://bugs.gentoo.org/713962